### PR TITLE
Update dependencies to Yew 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 resolver = "2"
 members = ["crates/*", "examples/*"]
+
+[workspace.dependencies]
+yew = { version = "0.23", features = ["csr"] }

--- a/crates/yewdux-input/Cargo.toml
+++ b/crates/yewdux-input/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2021"
 yewdux = { path = "../yewdux" }
 web-sys = "0.3"
 wasm-bindgen = "0.2"
-yew = "0.22"
+yew = "0.23"
 chrono = "0.4"
 serde = { version = "1.0", features = ["rc"] }

--- a/crates/yewdux/Cargo.toml
+++ b/crates/yewdux/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1.0"
 slab = "0.4"
 thiserror = "1.0"
 web-sys = "0.3"
-yew = "0.23"
+yew.workspace = true
 # yew = { version = "0.22" }
 # yewdux-macros = "0.11.0"
 yewdux-macros = { path = "../yewdux-macros" }

--- a/crates/yewdux/Cargo.toml
+++ b/crates/yewdux/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1.0"
 slab = "0.4"
 thiserror = "1.0"
 web-sys = "0.3"
-yew = "0.22"
+yew = "0.23"
 # yew = { version = "0.22" }
 # yewdux-macros = "0.11.0"
 yewdux-macros = { path = "../yewdux-macros" }

--- a/examples/async_proxy/Cargo.toml
+++ b/examples/async_proxy/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 wasm-bindgen-futures = "0.4.30"
-yew = { version = "0.22", features = ["csr"] }
+yew = { version = "0.23", features = ["csr"] }
 yewdux = { path = "../../crates/yewdux" }
 reqwasm = "0.5.0"
 serde = "1.0.140"

--- a/examples/async_proxy/Cargo.toml
+++ b/examples/async_proxy/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 wasm-bindgen-futures = "0.4.30"
-yew = { version = "0.23", features = ["csr"] }
+yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }
 reqwasm = "0.5.0"
 serde = "1.0.140"

--- a/examples/async_proxy/Cargo.toml
+++ b/examples/async_proxy/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wasm-bindgen-futures = "0.4.30"
+wasm-bindgen-futures = "0.4.64"
 yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }
 reqwasm = "0.5.0"
-serde = "1.0.140"
-serde_json = "1.0.82"
-web-sys = "0.3.59"
+serde = "1.0.228"
+serde_json = "1.0.149"
+web-sys = "0.3.91"

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yew = { version = "0.23", features = ["csr"] }
+yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yew = { version = "0.22", features = ["csr"] }
+yew = { version = "0.23", features = ["csr"] }
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/context_root/Cargo.toml
+++ b/examples/context_root/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yew = { version = "0.23", features = ["csr"] }
+yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/context_root/Cargo.toml
+++ b/examples/context_root/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yew = { version = "0.22", features = ["csr"] }
+yew = { version = "0.23", features = ["csr"] }
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/derived_from/Cargo.toml
+++ b/examples/derived_from/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yew = { version = "0.23", features = ["csr"] }
+yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/derived_from/Cargo.toml
+++ b/examples/derived_from/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yew = { version = "0.22", features = ["csr"] }
+yew = { version = "0.23", features = ["csr"] }
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/dynamic-render/Cargo.toml
+++ b/examples/dynamic-render/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yew = { version = "0.23", features = ["csr"] }
+yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/dynamic-render/Cargo.toml
+++ b/examples/dynamic-render/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yew = { version = "0.22", features = ["csr"] }
+yew = { version = "0.23", features = ["csr"] }
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/future/Cargo.toml
+++ b/examples/future/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 wasm-bindgen-futures = "0.4.30"
-yew = { version = "0.22", features = ["csr"] }
+yew = { version = "0.23", features = ["csr"] }
 yewdux = { path = "../../crates/yewdux" }
 serde = "1.0"
 gloo-net = "0.4"

--- a/examples/future/Cargo.toml
+++ b/examples/future/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wasm-bindgen-futures = "0.4.30"
+wasm-bindgen-futures = "0.4.64"
 yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }
 serde = "1.0"

--- a/examples/future/Cargo.toml
+++ b/examples/future/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 wasm-bindgen-futures = "0.4.30"
-yew = { version = "0.23", features = ["csr"] }
+yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }
 serde = "1.0"
 gloo-net = "0.4"

--- a/examples/history/Cargo.toml
+++ b/examples/history/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yew = { version = "0.23", features = ["csr"] }
+yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }
 yewdux-utils = { path = "../../crates/yewdux-utils" }

--- a/examples/history/Cargo.toml
+++ b/examples/history/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yew = { version = "0.22", features = ["csr"] }
+yew = { version = "0.23", features = ["csr"] }
 yewdux = { path = "../../crates/yewdux" }
 yewdux-utils = { path = "../../crates/yewdux-utils" }

--- a/examples/input/Cargo.toml
+++ b/examples/input/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 
 [dependencies]
 chrono = "0.4.22"
-yew = { version = "0.23", features = ["csr"] }
+yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }
 yewdux-input = { path = "../../crates/yewdux-input" }

--- a/examples/input/Cargo.toml
+++ b/examples/input/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = "0.4.22"
+chrono = "0.4.44"
 yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }
 yewdux-input = { path = "../../crates/yewdux-input" }

--- a/examples/input/Cargo.toml
+++ b/examples/input/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 
 [dependencies]
 chrono = "0.4.22"
-yew = { version = "0.22", features = ["csr"] }
+yew = { version = "0.23", features = ["csr"] }
 yewdux = { path = "../../crates/yewdux" }
 yewdux-input = { path = "../../crates/yewdux-input" }

--- a/examples/listener/Cargo.toml
+++ b/examples/listener/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.114" }
 wasm-logger = "0.2.0"
-yew = { version = "0.23", features = ["csr"] }
+yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/listener/Cargo.toml
+++ b/examples/listener/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0.114" }
+serde = { version = "1.0.228" }
 wasm-logger = "0.2.0"
 yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/listener/Cargo.toml
+++ b/examples/listener/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.114" }
 wasm-logger = "0.2.0"
-yew = { version = "0.22", features = ["csr"] }
+yew = { version = "0.23", features = ["csr"] }
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/manual/Cargo.toml
+++ b/examples/manual/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0.114", features = ["rc"] }
-yew = { version = "0.22", features = ["csr"] }
+yew = { version = "0.23", features = ["csr"] }
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/manual/Cargo.toml
+++ b/examples/manual/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0.114", features = ["rc"] }
+serde = { version = "1.0.228", features = ["rc"] }
 yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/manual/Cargo.toml
+++ b/examples/manual/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0.114", features = ["rc"] }
-yew = { version = "0.23", features = ["csr"] }
+yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/multi_component/Cargo.toml
+++ b/examples/multi_component/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0.114", features = ["rc"] }
-yew = { version = "0.22", features = ["csr"] }
+yew = { version = "0.23", features = ["csr"] }
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/multi_component/Cargo.toml
+++ b/examples/multi_component/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0.114", features = ["rc"] }
+serde = { version = "1.0.228", features = ["rc"] }
 yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/multi_component/Cargo.toml
+++ b/examples/multi_component/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0.114", features = ["rc"] }
-yew = { version = "0.23", features = ["csr"] }
+yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/no_copy/Cargo.toml
+++ b/examples/no_copy/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yew = { version = "0.23", features = ["csr"] }
+yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/no_copy/Cargo.toml
+++ b/examples/no_copy/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yew = { version = "0.22", features = ["csr"] }
+yew = { version = "0.23", features = ["csr"] }
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/persistent/Cargo.toml
+++ b/examples/persistent/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.114" }
 wasm-logger = "0.2.0"
-yew = { version = "0.23", features = ["csr"] }
+yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/persistent/Cargo.toml
+++ b/examples/persistent/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0.114" }
+serde = { version = "1.0.228" }
 wasm-logger = "0.2.0"
 yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/persistent/Cargo.toml
+++ b/examples/persistent/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.114" }
 wasm-logger = "0.2.0"
-yew = { version = "0.22", features = ["csr"] }
+yew = { version = "0.23", features = ["csr"] }
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/reducer/Cargo.toml
+++ b/examples/reducer/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yew = { version = "0.23", features = ["csr"] }
+yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/reducer/Cargo.toml
+++ b/examples/reducer/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yew = { version = "0.22", features = ["csr"] }
+yew = { version = "0.23", features = ["csr"] }
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/selector/Cargo.toml
+++ b/examples/selector/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yew = { version = "0.23", features = ["csr"] }
+yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/selector/Cargo.toml
+++ b/examples/selector/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yew = { version = "0.22", features = ["csr"] }
+yew = { version = "0.23", features = ["csr"] }
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/tab_sync/Cargo.toml
+++ b/examples/tab_sync/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0.114" }
-yew = { version = "0.22", features = ["csr"] }
+yew = { version = "0.23", features = ["csr"] }
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/tab_sync/Cargo.toml
+++ b/examples/tab_sync/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0.114" }
+serde = { version = "1.0.228" }
 yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/tab_sync/Cargo.toml
+++ b/examples/tab_sync/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0.114" }
-yew = { version = "0.23", features = ["csr"] }
+yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 serde = "1"
 strum = "0.25"
 strum_macros = "0.25"
-yew = { version = "0.22", features = ["csr"] }
+yew = { version = "0.23", features = ["csr"] }
 yewdux = { path = "../../crates/yewdux" }
 
 [dependencies.web-sys]

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 serde = "1"
 strum = "0.25"
 strum_macros = "0.25"
-yew = { version = "0.23", features = ["csr"] }
+yew.workspace = true
 yewdux = { path = "../../crates/yewdux" }
 
 [dependencies.web-sys]


### PR DESCRIPTION
This PR updates the dependencies to yew v0.23 and changes it to a workspace dependency so that the required version can be maintained in one place instead of having it spread across all the individual Cargo.toml files.